### PR TITLE
Remove max value from offset and limit parameters

### DIFF
--- a/predicthq/endpoints/schemas.py
+++ b/predicthq/endpoints/schemas.py
@@ -179,12 +179,12 @@ class IntRange(Model):
 
 class LimitMixin(Model):
 
-    limit = IntType(min_value=1, max_value=200)
+    limit = IntType(min_value=1)
 
 
 class OffsetMixin(Model):
 
-    offset = IntType(min_value=0, max_value=50)
+    offset = IntType(min_value=0)
 
 
 class PaginatedMixin(LimitMixin, OffsetMixin):


### PR DESCRIPTION
The actual maximums for these params vary by plan/subscription, so to
support all don't try and validate against a limit.