### PR TITLE
Add the ability to filter out brand unsafe events

### DIFF
--- a/predicthq/endpoints/schemas.py
+++ b/predicthq/endpoints/schemas.py
@@ -203,6 +203,14 @@ class IntRange(Model):
     lte = IntType()
 
 
+class BrandUnsafe(Model):
+
+    class Options:
+        serialize_when_none = False
+
+    exclude = BooleanType()
+
+
 class LimitMixin(Model):
 
     limit = IntType(min_value=1)

--- a/predicthq/endpoints/v1/events/schemas.py
+++ b/predicthq/endpoints/v1/events/schemas.py
@@ -5,7 +5,7 @@ from predicthq.endpoints.schemas import (
     PaginatedMixin, SortableMixin, Model, ResultSet, ListType, StringType, GeoJSONPointType,
     StringListType, StringModelType, Area, ModelType, IntRange, IntType, DateTimeRange,
     DateTimeType, FloatType, ResultType, DictType, DateType, Place, Signal, DateAround,
-    LocationAround, BooleanType
+    LocationAround, BooleanType, BrandUnsafe
 )
 
 
@@ -35,6 +35,7 @@ class SearchParams(PaginatedMixin, SortableMixin, Model):
     place = ModelType(Place)
     signal = ModelType(Signal)
     relevance = ListType(StringType)
+    brand_unsafe = ModelType(BrandUnsafe)
 
 
 class Event(Model):


### PR DESCRIPTION
Examples of brand-unsafe events include content that promotes hate, violence or discrimination, coarse language, content that is sexually suggestive or explicit, etc.