### PR TITLE
Set end datetime ranges to 23:59:59 on the same day

### DIFF
--- a/predicthq/endpoints/schemas.py
+++ b/predicthq/endpoints/schemas.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, date
+from datetime import datetime, date, time as dt_time
 from urllib.parse import parse_qsl, urlparse
 
 import pytz
@@ -24,6 +24,14 @@ class DateTimeType(SchematicsDateTimeType):
         if isinstance(value, datetime):
             return value
         return parse_date(value)
+
+
+class DateTimeEndType(SchematicsDateTimeType):
+
+    def to_native(self, value, context=None):
+        if isinstance(value, datetime):
+            return value
+        return datetime.combine(parse_date(value), dt_time.max)
 
 
 class DateType(SchematicsDateType):
@@ -156,8 +164,8 @@ class DateTimeRange(Model):
 
     gt = DateTimeType()
     gte = DateTimeType()
-    lt = DateTimeType()
-    lte = DateTimeType()
+    lt = DateTimeEndType()
+    lte = DateTimeEndType()
     tz = StringType(choices=pytz.all_timezones)
 
 

--- a/tests/endpoints/v1/test_events.py
+++ b/tests/endpoints/v1/test_events.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import datetime
 
 from predicthq.endpoints.v1.events.schemas import EventResultSet, CalendarResultSet, Count
 from tests import with_mock_client, with_mock_responses, with_client
@@ -10,16 +9,16 @@ class EventsTest(unittest.TestCase):
     @with_mock_client()
     def test_search_params_underscores(self, client):
         client.events.search(
-            id="id", q="query", country=["NZ", "AU"],
+            id='id', q='query', country=['NZ', 'AU'],
             rank_level=[4, 5], rank__gt=85,  local_rank_level=[4, 5], local_rank__gt=85,
-            within__radius="2km", within__longitude=-71.0432, within__latitude=42.346,
-            label=["label1", "label2"], category="category", state='deleted',
+            within__radius='2km', within__longitude=-71.0432, within__latitude=42.346,
+            label=['label1', 'label2'], category='category', state='deleted',
             start_around__origin='2016-03-05', start_around__scale='5d',
-            place__scope=["place1", "place2"], place__exact=["place3"],
-            start__gte="2016-03-01", start__lt="2016-04-01", start__tz="Pacific/Auckland",
-            end__gte="2016-05-01", end__lt="2016-06-01", end__tz="Pacific/Auckland",
-            active__gte="2016-03-01", active__lt="2016-04-01", active__tz="Pacific/Auckland",
-            updated__gte="2016-03-01", updated__lt="2016-04-01", updated__tz="Pacific/Auckland",
+            place__scope=['place1', 'place2'], place__exact=['place3'],
+            start__gte='2016-03-01', start__lt='2016-04-01', start__tz='Pacific/Auckland',
+            end__gte='2016-05-01', end__lt='2016-06-01', end__tz='Pacific/Auckland',
+            active__gte='2016-03-01', active__lt='2016-04-01', active__tz='Pacific/Auckland',
+            updated__gte='2016-03-01', updated__lt='2016-04-01', updated__tz='Pacific/Auckland',
         )
 
         client.request.assert_called_once_with(
@@ -40,16 +39,16 @@ class EventsTest(unittest.TestCase):
     @with_mock_client()
     def test_search_params_dicts(self, client):
         client.events.search(
-            id="id", q="query", country=["NZ", "AU"],
-            rank_level=[4, 5], rank={"gt": 85},
-            within={"radius": "2km", "longitude": -71.0432, "latitude": 42.346},
-            label=["label1", "label2"], category="category", state='deleted',
-            place={"scope": ["place1", "place2"], "exact": "place3"},
+            id='id', q='query', country=['NZ', 'AU'],
+            rank_level=[4, 5], rank={'gt': 85},
+            within={'radius': '2km', 'longitude': -71.0432, 'latitude': 42.346},
+            label=['label1', 'label2'], category='category', state='deleted',
+            place={'scope': ['place1', 'place2'], 'exact': 'place3'},
             location_around={'origin': '40.730610,-73.935242', 'scale': '2km', 'offset': '0.5km'},
-            start={"gte": "2016-03-01", "lt": "2016-04-01", "tz": "Pacific/Auckland"},
-            end={"gte": "2016-05-01", "lt": "2016-06-01", "tz": "Pacific/Auckland"},
-            active={"gte": "2016-03-01", "lt": "2016-04-01", "tz": "Pacific/Auckland"},
-            updated={"gte": "2016-03-01", "lt": "2016-04-01", "tz": "Pacific/Auckland"},
+            start={'gte': '2016-03-01', 'lt': '2016-04-01', 'tz': 'Pacific/Auckland'},
+            end={'gte': '2016-05-01', 'lt': '2016-06-01', 'tz': 'Pacific/Auckland'},
+            active={'gte': '2016-03-01', 'lt': '2016-04-01', 'tz': 'Pacific/Auckland'},
+            updated={'gte': '2016-03-01', 'lt': '2016-04-01', 'tz': 'Pacific/Auckland'},
         )
 
         client.request.assert_called_once_with(
@@ -69,13 +68,13 @@ class EventsTest(unittest.TestCase):
 
     @with_mock_client()
     def test_search_for_account(self, client):
-        client.events.for_account('account-id').search(q="query")
+        client.events.for_account('account-id').search(q='query')
         client.request.assert_called_once_with('get', '/v1/accounts/account-id/events/', params={'q': 'query'})
 
     @with_client()
     @with_mock_responses()
     def test_search(self, client, responses):
-        result = client.events.search(q="Foo Fighters", country="AU", limit=10)
+        result = client.events.search(q='Foo Fighters', country='AU', limit=10)
         assert isinstance(result, EventResultSet)
         assert result.count == len(list(result.iter_all()))
         assert len(responses.calls) == 2
@@ -83,14 +82,14 @@ class EventsTest(unittest.TestCase):
     @with_client()
     @with_mock_responses()
     def test_count(self, client, responses):
-        result = client.events.count(active__gte="2015-01-01", active__lte="2015-12-31", within="50km@-27.470784,153.030124")
+        result = client.events.count(active__gte='2015-01-01', active__lte='2015-12-31', within='50km@-27.470784,153.030124')
         assert isinstance(result, Count)
         assert result.count == 2501
 
     @with_client()
     @with_mock_responses()
     def test_calendar(self, client, responses):
-        result = client.events.calendar(active__gte="2015-12-24", active__lte="2015-12-26", country="NZ", top_events__limit=1, top_events__sort=["rank"], active__tz="Pacific/Auckland")
+        result = client.events.calendar(active__gte='2015-12-24', active__lte='2015-12-26', country='NZ', top_events__limit=1, top_events__sort=['rank'], active__tz='Pacific/Auckland')
         assert isinstance(result, CalendarResultSet)
         assert result.count == 60
         assert len(list(result.iter_all())) == 3

--- a/tests/endpoints/v1/test_events.py
+++ b/tests/endpoints/v1/test_events.py
@@ -16,10 +16,10 @@ class EventsTest(unittest.TestCase):
             label=["label1", "label2"], category="category", state='deleted',
             start_around__origin='2016-03-05', start_around__scale='5d',
             place__scope=["place1", "place2"], place__exact=["place3"],
-            start__gte="2016-03-01", start__lt=datetime(2016, 4, 1), start__tz="Pacific/Auckland",
-            end__gte="2016-05-01", end__lt=datetime(2016, 6, 1), end__tz="Pacific/Auckland",
-            active__gte="2016-03-01", active__lt=datetime(2016, 4, 1), active__tz="Pacific/Auckland",
-            updated__gte="2016-03-01", updated__lt=datetime(2016, 4, 1), updated__tz="Pacific/Auckland",
+            start__gte="2016-03-01", start__lt="2016-04-01", start__tz="Pacific/Auckland",
+            end__gte="2016-05-01", end__lt="2016-06-01", end__tz="Pacific/Auckland",
+            active__gte="2016-03-01", active__lt="2016-04-01", active__tz="Pacific/Auckland",
+            updated__gte="2016-03-01", updated__lt="2016-04-01", updated__tz="Pacific/Auckland",
         )
 
         client.request.assert_called_once_with(
@@ -30,10 +30,10 @@ class EventsTest(unittest.TestCase):
                 'label': 'label1,label2', 'category': 'category', 'state': 'deleted',
                 'start_around.origin': '2016-03-05', 'start_around.scale': '5d',
                 'place.scope': 'place1,place2', 'place.exact': 'place3',
-                'start.gte': '2016-03-01T00:00:00.000000', 'start.lt': '2016-04-01T00:00:00.000000', 'start.tz': 'Pacific/Auckland',
-                'end.gte': '2016-05-01T00:00:00.000000', 'end.lt': '2016-06-01T00:00:00.000000', 'end.tz': 'Pacific/Auckland',
-                'active.gte': '2016-03-01T00:00:00.000000', 'active.lt': '2016-04-01T00:00:00.000000', 'active.tz': 'Pacific/Auckland',
-                'updated.gte': '2016-03-01T00:00:00.000000', 'updated.lt': '2016-04-01T00:00:00.000000', 'updated.tz': 'Pacific/Auckland',
+                'start.gte': '2016-03-01T00:00:00.000000', 'start.lt': '2016-04-01T23:59:59.999999', 'start.tz': 'Pacific/Auckland',
+                'end.gte': '2016-05-01T00:00:00.000000', 'end.lt': '2016-06-01T23:59:59.999999', 'end.tz': 'Pacific/Auckland',
+                'active.gte': '2016-03-01T00:00:00.000000', 'active.lt': '2016-04-01T23:59:59.999999', 'active.tz': 'Pacific/Auckland',
+                'updated.gte': '2016-03-01T00:00:00.000000', 'updated.lt': '2016-04-01T23:59:59.999999', 'updated.tz': 'Pacific/Auckland',
             }
         )
 
@@ -46,10 +46,10 @@ class EventsTest(unittest.TestCase):
             label=["label1", "label2"], category="category", state='deleted',
             place={"scope": ["place1", "place2"], "exact": "place3"},
             location_around={'origin': '40.730610,-73.935242', 'scale': '2km', 'offset': '0.5km'},
-            start={"gte": "2016-03-01", "lt": datetime(2016, 4, 1), "tz": "Pacific/Auckland"},
-            end={"gte": "2016-05-01", "lt": datetime(2016, 6, 1), "tz": "Pacific/Auckland"},
-            active={"gte": "2016-03-01", "lt": datetime(2016, 4, 1), "tz": "Pacific/Auckland"},
-            updated={"gte": "2016-03-01", "lt": datetime(2016, 4, 1), "tz": "Pacific/Auckland"},
+            start={"gte": "2016-03-01", "lt": "2016-04-01", "tz": "Pacific/Auckland"},
+            end={"gte": "2016-05-01", "lt": "2016-06-01", "tz": "Pacific/Auckland"},
+            active={"gte": "2016-03-01", "lt": "2016-04-01", "tz": "Pacific/Auckland"},
+            updated={"gte": "2016-03-01", "lt": "2016-04-01", "tz": "Pacific/Auckland"},
         )
 
         client.request.assert_called_once_with(
@@ -60,10 +60,10 @@ class EventsTest(unittest.TestCase):
                 'label': 'label1,label2', 'category': 'category', 'state': 'deleted',
                 'place.scope': 'place1,place2', 'place.exact': 'place3',
                 'location_around.origin': '40.730610,-73.935242', 'location_around.scale': '2km', 'location_around.offset': '0.5km',
-                'start.gte': '2016-03-01T00:00:00.000000', 'start.lt': '2016-04-01T00:00:00.000000', 'start.tz': 'Pacific/Auckland',
-                'end.gte': '2016-05-01T00:00:00.000000', 'end.lt': '2016-06-01T00:00:00.000000', 'end.tz': 'Pacific/Auckland',
-                'active.gte': '2016-03-01T00:00:00.000000', 'active.lt': '2016-04-01T00:00:00.000000', 'active.tz': 'Pacific/Auckland',
-                'updated.gte': '2016-03-01T00:00:00.000000', 'updated.lt': '2016-04-01T00:00:00.000000', 'updated.tz': 'Pacific/Auckland',
+                'start.gte': '2016-03-01T00:00:00.000000', 'start.lt': '2016-04-01T23:59:59.999999', 'start.tz': 'Pacific/Auckland',
+                'end.gte': '2016-05-01T00:00:00.000000', 'end.lt': '2016-06-01T23:59:59.999999', 'end.tz': 'Pacific/Auckland',
+                'active.gte': '2016-03-01T00:00:00.000000', 'active.lt': '2016-04-01T23:59:59.999999', 'active.tz': 'Pacific/Auckland',
+                'updated.gte': '2016-03-01T00:00:00.000000', 'updated.lt': '2016-04-01T23:59:59.999999', 'updated.tz': 'Pacific/Auckland',
             }
         )
 

--- a/tests/endpoints/v1/test_events.py
+++ b/tests/endpoints/v1/test_events.py
@@ -24,22 +24,24 @@ class EventsTest(unittest.TestCase):
 
         client.request.assert_called_once_with(
             'get', '/v1/events/', params={
-                'id': 'id', 'category': 'category', 'state': 'deleted', 'country': 'NZ,AU',
-                'rank.gt': 85, 'rank_level': '4,5', 'local_rank.gt': 85, 'local_rank_level': '4,5',
-                'within': '2km@42.346,-71.0432', 'label': 'label1,label2', 'q': 'query',
+                'id': 'id', 'q': 'query', 'country': 'NZ,AU',
+                'rank_level': '4,5', 'rank.gt': 85, 'local_rank_level': '4,5', 'local_rank.gt': 85,
+                'within': '2km@42.346,-71.0432',
+                'label': 'label1,label2', 'category': 'category', 'state': 'deleted',
                 'start_around.origin': '2016-03-05', 'start_around.scale': '5d',
                 'place.scope': 'place1,place2', 'place.exact': 'place3',
-                'start.lt': '2016-04-01T00:00:00.000000', 'start.gte': '2016-03-01T00:00:00.000000', 'start.tz': 'Pacific/Auckland',
-                'end.lt': '2016-06-01T00:00:00.000000', 'end.gte': '2016-05-01T00:00:00.000000', 'end.tz': 'Pacific/Auckland',
-                'active.lt': '2016-04-01T00:00:00.000000', 'active.gte': '2016-03-01T00:00:00.000000', 'active.tz': 'Pacific/Auckland',
-                'updated.lt': '2016-04-01T00:00:00.000000', 'updated.gte': '2016-03-01T00:00:00.000000', 'updated.tz': 'Pacific/Auckland',
+                'start.gte': '2016-03-01T00:00:00.000000', 'start.lt': '2016-04-01T00:00:00.000000', 'start.tz': 'Pacific/Auckland',
+                'end.gte': '2016-05-01T00:00:00.000000', 'end.lt': '2016-06-01T00:00:00.000000', 'end.tz': 'Pacific/Auckland',
+                'active.gte': '2016-03-01T00:00:00.000000', 'active.lt': '2016-04-01T00:00:00.000000', 'active.tz': 'Pacific/Auckland',
+                'updated.gte': '2016-03-01T00:00:00.000000', 'updated.lt': '2016-04-01T00:00:00.000000', 'updated.tz': 'Pacific/Auckland',
             }
         )
 
     @with_mock_client()
     def test_search_params_dicts(self, client):
         client.events.search(
-            id="id", q="query", rank_level=[4, 5], rank={"gt": 85}, country=["NZ", "AU"],
+            id="id", q="query", country=["NZ", "AU"],
+            rank_level=[4, 5], rank={"gt": 85},
             within={"radius": "2km", "longitude": -71.0432, "latitude": 42.346},
             label=["label1", "label2"], category="category", state='deleted',
             place={"scope": ["place1", "place2"], "exact": "place3"},
@@ -52,14 +54,16 @@ class EventsTest(unittest.TestCase):
 
         client.request.assert_called_once_with(
             'get', '/v1/events/', params={
-                'id': 'id', 'rank.gt': 85, 'rank_level': '4,5', 'category': 'category', 'state': 'deleted', 'country': 'NZ,AU',
-                'within': '2km@42.346,-71.0432', 'label': 'label1,label2', 'q': 'query',
+                'id': 'id', 'q': 'query', 'country': 'NZ,AU',
+                'rank_level': '4,5', 'rank.gt': 85,
+                'within': '2km@42.346,-71.0432',
+                'label': 'label1,label2', 'category': 'category', 'state': 'deleted',
                 'place.scope': 'place1,place2', 'place.exact': 'place3',
                 'location_around.origin': '40.730610,-73.935242', 'location_around.scale': '2km', 'location_around.offset': '0.5km',
-                'start.lt': '2016-04-01T00:00:00.000000', 'start.gte': '2016-03-01T00:00:00.000000', 'start.tz': 'Pacific/Auckland',
-                'end.lt': '2016-06-01T00:00:00.000000', 'end.gte': '2016-05-01T00:00:00.000000', 'end.tz': 'Pacific/Auckland',
-                'active.lt': '2016-04-01T00:00:00.000000', 'active.gte': '2016-03-01T00:00:00.000000', 'active.tz': 'Pacific/Auckland',
-                'updated.lt': '2016-04-01T00:00:00.000000', 'updated.gte': '2016-03-01T00:00:00.000000', 'updated.tz': 'Pacific/Auckland',
+                'start.gte': '2016-03-01T00:00:00.000000', 'start.lt': '2016-04-01T00:00:00.000000', 'start.tz': 'Pacific/Auckland',
+                'end.gte': '2016-05-01T00:00:00.000000', 'end.lt': '2016-06-01T00:00:00.000000', 'end.tz': 'Pacific/Auckland',
+                'active.gte': '2016-03-01T00:00:00.000000', 'active.lt': '2016-04-01T00:00:00.000000', 'active.tz': 'Pacific/Auckland',
+                'updated.gte': '2016-03-01T00:00:00.000000', 'updated.lt': '2016-04-01T00:00:00.000000', 'updated.tz': 'Pacific/Auckland',
             }
         )
 

--- a/tests/fixtures/requests_responses/events_test/test_count.json
+++ b/tests/fixtures/requests_responses/events_test/test_count.json
@@ -2,7 +2,7 @@
   {
     "method": "GET",
     "match_querystring": true,
-    "url": "/v1/events/count/?active.gte=2015-01-01T00%3A00%3A00.000000&active.lte=2015-12-31T00%3A00%3A00.000000&within=50km%40-27.470784%2C153.030124",
+    "url": "/v1/events/count/?active.gte=2015-01-01T00%3A00%3A00.000000&active.lte=2015-12-31T23%3A59%3A59.999999&within=50km%40-27.470784%2C153.030124",
     "status": 200,
     "content_type": "application/json",
     "body": {


### PR DESCRIPTION
When passing a date to a DateTimeType range filter, we used to set the time to midnight for both the start and the end range filters. So the following search parameters

`start__gte='2019-12-25', start__lte='2019-12-25'`

would be converted in the sdk to

`'start.gte': '2016-12-25T00:00:00.000000', 'start.lte': '2016-12-25T00:00:00.000000'`

This would exclude an event with the following start value

`'start': '2016-12-25T05:00:00.000000'`

This commits sets the end filters (`lt`, `lte`) to the datetime max for the day, i.e., `23:59:59.999999`. So the parameters mentioned above would now get converted to

`'start.gte': '2016-12-25T00:00:00.000000', 'start.lte': '2016-12-25T23:59:59.999999'`

and would include the event mentioned above.