### PR TITLE
Add location.origin broadcasts search param

### DIFF
--- a/predicthq/endpoints/v1/broadcasts/schemas.py
+++ b/predicthq/endpoints/v1/broadcasts/schemas.py
@@ -20,6 +20,7 @@ class BroadcastLocationParams(Model):
     class Options:
         serialize_when_none = False
 
+    origin = origin = StringType(regex=r'(-?\d+(\.\d+)?),(-?\d+(\.\d+)?)')
     place_id = ListType(StringType)
 
 

--- a/tests/endpoints/v1/test_broadcasts.py
+++ b/tests/endpoints/v1/test_broadcasts.py
@@ -10,7 +10,7 @@ class BroadcastsTest(unittest.TestCase):
     def test_search_params_underscores(self, client):
         client.broadcasts.search(
             broadcast_id='broadcast_id',
-            location__place_id='place_id',
+            location__origin='0,0', location__place_id='place_id',
             phq_viewership__gte=1, phq_viewership__lte=10,
             start__gte='2020-10-01', start__lt='2020-10-15', start__tz='Pacific/Auckland',
             updated__gte='2020-11-01', updated__lt='2020-11-30', updated__tz='Pacific/Auckland',
@@ -21,7 +21,7 @@ class BroadcastsTest(unittest.TestCase):
         client.request.assert_called_once_with(
             'get', '/v1/broadcasts/', params={
                 'broadcast_id': 'broadcast_id',
-                'location.place_id': 'place_id',
+                'location.origin': '0,0', 'location.place_id': 'place_id',
                 'phq_viewership.gte': 1, 'phq_viewership.lte': 10,
                 'start.gte': '2020-10-01T00:00:00.000000', 'start.lt': '2020-10-15T23:59:59.999999', 'start.tz': 'Pacific/Auckland',
                 'updated.gte': '2020-11-01T00:00:00.000000', 'updated.lt': '2020-11-30T23:59:59.999999', 'updated.tz': 'Pacific/Auckland',
@@ -34,7 +34,7 @@ class BroadcastsTest(unittest.TestCase):
     def test_search_params_dicts(self, client):
         client.broadcasts.search(
             broadcast_id='broadcast_id',
-            location={'place_id': 'place_id'},
+            location={'origin': '0,0', 'place_id': 'place_id'},
             phq_viewership={'gte': 1, 'lte': 10},
             start={'gte': '2020-10-01', 'lt': '2020-10-15', 'tz': 'Pacific/Auckland'},
             updated={'gte': '2020-11-01', 'lt': '2020-11-30', 'tz': 'Pacific/Auckland'},
@@ -45,7 +45,7 @@ class BroadcastsTest(unittest.TestCase):
         client.request.assert_called_once_with(
             'get', '/v1/broadcasts/', params={
                 'broadcast_id': 'broadcast_id',
-                'location.place_id': 'place_id',
+                'location.origin': '0,0', 'location.place_id': 'place_id',
                 'phq_viewership.gte': 1, 'phq_viewership.lte': 10,
                 'start.gte': '2020-10-01T00:00:00.000000', 'start.lt': '2020-10-15T23:59:59.999999', 'start.tz': 'Pacific/Auckland',
                 'updated.gte': '2020-11-01T00:00:00.000000', 'updated.lt': '2020-11-30T23:59:59.999999', 'updated.tz': 'Pacific/Auckland',

--- a/tests/endpoints/v1/test_broadcasts.py
+++ b/tests/endpoints/v1/test_broadcasts.py
@@ -10,7 +10,7 @@ class BroadcastsTest(unittest.TestCase):
     def test_search_params_underscores(self, client):
         client.broadcasts.search(
             broadcast_id='broadcast_id',
-            location__origin='0,0', location__place_id='place_id',
+            location__origin='34.05223,-118.24368', location__place_id='place_id',
             phq_viewership__gte=1, phq_viewership__lte=10,
             start__gte='2020-10-01', start__lt='2020-10-15', start__tz='Pacific/Auckland',
             updated__gte='2020-11-01', updated__lt='2020-11-30', updated__tz='Pacific/Auckland',
@@ -21,7 +21,7 @@ class BroadcastsTest(unittest.TestCase):
         client.request.assert_called_once_with(
             'get', '/v1/broadcasts/', params={
                 'broadcast_id': 'broadcast_id',
-                'location.origin': '0,0', 'location.place_id': 'place_id',
+                'location.origin': '34.05223,-118.24368', 'location.place_id': 'place_id',
                 'phq_viewership.gte': 1, 'phq_viewership.lte': 10,
                 'start.gte': '2020-10-01T00:00:00.000000', 'start.lt': '2020-10-15T23:59:59.999999', 'start.tz': 'Pacific/Auckland',
                 'updated.gte': '2020-11-01T00:00:00.000000', 'updated.lt': '2020-11-30T23:59:59.999999', 'updated.tz': 'Pacific/Auckland',
@@ -34,7 +34,7 @@ class BroadcastsTest(unittest.TestCase):
     def test_search_params_dicts(self, client):
         client.broadcasts.search(
             broadcast_id='broadcast_id',
-            location={'origin': '0,0', 'place_id': 'place_id'},
+            location={'origin': '34.05223,-118.24368', 'place_id': 'place_id'},
             phq_viewership={'gte': 1, 'lte': 10},
             start={'gte': '2020-10-01', 'lt': '2020-10-15', 'tz': 'Pacific/Auckland'},
             updated={'gte': '2020-11-01', 'lt': '2020-11-30', 'tz': 'Pacific/Auckland'},
@@ -45,7 +45,7 @@ class BroadcastsTest(unittest.TestCase):
         client.request.assert_called_once_with(
             'get', '/v1/broadcasts/', params={
                 'broadcast_id': 'broadcast_id',
-                'location.origin': '0,0', 'location.place_id': 'place_id',
+                'location.origin': '34.05223,-118.24368', 'location.place_id': 'place_id',
                 'phq_viewership.gte': 1, 'phq_viewership.lte': 10,
                 'start.gte': '2020-10-01T00:00:00.000000', 'start.lt': '2020-10-15T23:59:59.999999', 'start.tz': 'Pacific/Auckland',
                 'updated.gte': '2020-11-01T00:00:00.000000', 'updated.lt': '2020-11-30T23:59:59.999999', 'updated.tz': 'Pacific/Auckland',

--- a/usecases/broadcasts/basics.py
+++ b/usecases/broadcasts/basics.py
@@ -9,7 +9,7 @@ phq = Client(access_token=ACCESS_TOKEN)
 
 
 # The search() method returns an EventResultSet which allows you to iterate
-# over the first page of Broadcast objects (10 events by default)
+# over the first page of Broadcast objects (10 results by default)
 for broadcast in phq.broadcasts.search():
     print(broadcast.to_dict())
 


### PR DESCRIPTION
Add support for the location.origin param (https://docs.predicthq.com/resources/broadcasts/#param-location.origin) on the broadcasts endpoint.