### PR TITLE
Add phq attendance school holidays

### DIFF
--- a/predicthq/endpoints/v1/features/schemas.py
+++ b/predicthq/endpoints/v1/features/schemas.py
@@ -1,8 +1,8 @@
 from predicthq.endpoints.schemas import (
     BooleanType,
     ConfigMixin,
-    DateType,
     DateRange,
+    DateType,
     DictType,
     FloatType,
     IntRange,

--- a/predicthq/endpoints/v1/features/schemas.py
+++ b/predicthq/endpoints/v1/features/schemas.py
@@ -169,6 +169,7 @@ class Feature(Model):
     phq_attendance_expos = ModelType(FeatureStat)
     phq_attendance_festivals = ModelType(FeatureStat)
     phq_attendance_performing_arts = ModelType(FeatureStat)
+    phq_attendance_school_holidays = ModelType(FeatureStat)
     phq_attendance_sports = ModelType(FeatureStat)
     # Rank based features
     phq_rank_daylight_savings = ModelType(FeatureRankLevel)

--- a/predicthq/endpoints/v1/features/schemas.py
+++ b/predicthq/endpoints/v1/features/schemas.py
@@ -72,6 +72,7 @@ class FeatureRequest(ConfigMixin, Model):
     phq_attendance_expos = ModelType(FeatureCriteria)
     phq_attendance_festivals = ModelType(FeatureCriteria)
     phq_attendance_performing_arts = ModelType(FeatureCriteria)
+    phq_attendance_school_holidays = ModelType(FeatureCriteria)
     phq_attendance_sports = ModelType(FeatureCriteria)
     # Rank based feature criteria
     phq_rank_daylight_savings = BooleanType()

--- a/tests/endpoints/test_schemas.py
+++ b/tests/endpoints/test_schemas.py
@@ -1,8 +1,8 @@
-from datetime import datetime, date, time
-from dateutil.parser import parse as parse_date
+from datetime import date, datetime, time
 
 import pytest
 import pytz
+from dateutil.parser import parse as parse_date
 
 from predicthq.endpoints import decorators, schemas
 from predicthq.endpoints.base import BaseEndpoint

--- a/tests/endpoints/v1/test_features.py
+++ b/tests/endpoints/v1/test_features.py
@@ -105,6 +105,7 @@ class FeaturesTest(unittest.TestCase):
             phq_attendance_expos=feature_criteria,
             phq_attendance_festivals=feature_criteria,
             phq_attendance_performing_arts=feature_criteria,
+            phq_attendance_school_holidays=feature_criteria,
             phq_attendance_sports=feature_criteria,
         )
 
@@ -122,6 +123,7 @@ class FeaturesTest(unittest.TestCase):
                 "phq_attendance_expos": feature_criteria,
                 "phq_attendance_festivals": feature_criteria,
                 "phq_attendance_performing_arts": feature_criteria,
+                "phq_attendance_school_holidays": feature_criteria,
                 "phq_attendance_sports": feature_criteria,
             },
             verify=True,

--- a/tests/endpoints/v1/test_features.py
+++ b/tests/endpoints/v1/test_features.py
@@ -1,7 +1,7 @@
 import unittest
 
 from predicthq.endpoints.v1.features.schemas import FeatureResultSet
-from tests import with_mock_client, with_mock_responses, with_client
+from tests import with_client, with_mock_client, with_mock_responses
 
 
 class FeaturesTest(unittest.TestCase):


### PR DESCRIPTION
I noticed this attendance-based feature was missing.

Calling the API with
```
    "phq_attendance_school_holidays": {
        "phq_rank": {
            "gte": 10
        },
        "stats": ["count"]
    },
```
returns no error (it's a valid feature and param), but the SDK considers "phq_attendance_school_holidays" a rogue field.