### PR TITLE
fix: guard get_next/get_previous against unset _more

### DIFF
--- a/predicthq/endpoints/schemas.py
+++ b/predicthq/endpoints/schemas.py
@@ -29,13 +29,13 @@ class ResultSet(BaseModel):
         return self.next is not None
 
     def get_next(self):
-        if not self.has_next() or not hasattr(self, "_more"):
+        if not self.has_next() or self._more is None:
             return
         params = self._parse_params(self.next)
         return self._more(**params)
 
     def get_previous(self):
-        if not self.has_previous() or not hasattr(self, "_more"):
+        if not self.has_previous() or self._more is None:
             return
         params = self._parse_params(self.previous)
         return self._more(**params)

--- a/tests/endpoints/test_schemas.py
+++ b/tests/endpoints/test_schemas.py
@@ -135,3 +135,19 @@ def test_resultset():
         endpoint.load_page(page=3).model_dump(),
     ]
     assert list(p1.iter_all()) == list(p1) + list(p2) + list(p3)
+
+
+def test_resultset_without_more_returns_none():
+    # A ResultSet not produced by the @returns decorator has no _more callable set.
+    # _more is a declared private attr defaulting to None, so hasattr() is always
+    # True; get_next()/get_previous() must guard on `_more is None` and return None
+    # rather than raising "'NoneType' object is not callable".
+    result_set = schemas.ResultSet(
+        count=5,
+        next="https://example.org/?page=2",
+        previous="https://example.org/?page=1",
+    )
+    assert result_set.has_next() is True
+    assert result_set.has_previous() is True
+    assert result_set.get_next() is None
+    assert result_set.get_previous() is None


### PR DESCRIPTION
## Description

`ResultSet.get_next()` / `get_previous()` guard with `not hasattr(self, "_more")`, but `_more` is a **declared Pydantic private attribute** with a default of `None`:

```python
class ResultSet(BaseModel):
    _more: Optional[Callable] = None
```

Because the attribute is declared, `hasattr(self, "_more")` is **always `True`** (it resolves to the default `None`), so the guard never short-circuits. When `_more` has not been set — e.g. a `ResultSet` that wasn't produced by the `@returns` decorator — the methods fall through to `self._more(**params)` and raise:

```
TypeError: 'NoneType' object is not callable
```

This changes the guard to `self._more is None`, so `get_next()` / `get_previous()` return `None` as intended when there is no callable to page with. The normal decorator-driven flow (where `_more` is a `functools.partial`) is unchanged.

## Testing

Added `test_resultset_without_more_returns_none`, which constructs a `ResultSet` with `next`/`previous` set but no `_more` and asserts both accessors return `None`. Before the change this test raised `TypeError`; the existing `test_resultset` (decorator-driven paging) continues to pass.
